### PR TITLE
Fixed named tuple issue with python 2.x in ssdeep.pyx

### DIFF
--- a/ssdeep.pyx
+++ b/ssdeep.pyx
@@ -24,7 +24,7 @@ DEF FUZZY_MAX_RESULT = 116
 class Error(Exception):
     pass
 
-if sys.version_info.major == 2:
+if sys.version_info[0] == 2:
     def compare(char* sig1, char* sig2):
         """
         Compute the match score between two fuzzy hash signatures.


### PR DESCRIPTION
Fixed an issue with named tuples for version strings.  This was fixed when trying to build, but the ssdeep.pyx file has a similar issue that appears when one attempts to import the compiled code.
