### PR TITLE
Change execution method for configure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def build_ssdeep():
         pass
 
     returncode = subprocess.call(
-        "(cd ssdeep-lib && ./configure && make)",
+        "(cd ssdeep-lib && sh configure && make)",
         shell=True
     )
     if returncode == 0:
@@ -46,7 +46,7 @@ def build_ssdeep():
     print("Retry with autoreconf ...")
 
     returncode = subprocess.call(
-        "(cd ssdeep-lib && autoreconf --force && ./configure && make)",
+        "(cd ssdeep-lib && autoreconf --force && sh configure && make)",
         shell=True
     )
     if returncode != 0:


### PR DESCRIPTION
When installing on Windows with `setup.py` using MinGW32, I got the following error:

> '.' is not recognized as an internal or external command, operable program or batch file.
> Failed while building ssdeep lib with configure and make.

This pull request changes the two pieces of code calling `configure` to use `sh` instead of a direct execution.
