### PR TITLE
Six is not available in the old version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,12 +121,12 @@ setup(
     install_requires=[
         # ToDo: set min version
         "cffi",
-        "six >= 1.4.1"
+        "six >= 1.10.0"
     ],
     setup_requires=[
         # ToDo: set min version
         "cffi",
-        "six >= 1.4.1"
+        "six >= 1.10.0"
     ],
     packages=find_packages(exclude=["*.tests", "*.tests.*"]),
     include_package_data=True,


### PR DESCRIPTION
pip install six >= 1.4.1 does not work anymore I am not certain why but the latest version works. This fixes it.