### PR TITLE
Don't build included lib

### DIFF
--- a/ci/debian-8_python3-system/Dockerfile
+++ b/ci/debian-8_python3-system/Dockerfile
@@ -27,6 +27,6 @@ RUN apt-get install -y \
 
 COPY . /code
 RUN cd /code && \
-    BUILD_LIB=1 pip3 install . && \
+    BUILD_LIB=0 pip3 install . && \
     pip3 install pytest && \
     py.test


### PR DESCRIPTION
Don't build the included lib if we want to use the system lib.