### PR TITLE
setup.py bdist_rpm creates conflicting rpm

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[bdist_rpm]
+requires = python-cffi, python-six, libffi, ssdeep-libs
+build-requires = libffi-devel, ssdeep-devel
+

--- a/ssdeep/__about__.py
+++ b/ssdeep/__about__.py
@@ -9,7 +9,7 @@ __all__ = [
     "__version__",
 ]
 
-__title__ = "ssdeep"
+__title__ = "python-ssdeep"
 __summary__ = "Python wrapper for the ssdeep library"
 __uri__ = "http://github.com/DinoTools/python-ssdeep"
 


### PR DESCRIPTION
Building an rpm file using ```python setup.py bdist_rpm``` will generate an rpm file currently named ```ssdeep-3.2-1.x86_64.rpm``` which will conflict with ssdeep rpm from e.g. EPEL which would provide ssdeep binary.

My suggestion to resolve this issue: set  ```__title__ = "python-ssdeep"``` in ```ssdeep/__about__.py```

Addionally I added a setup.cfg to faciliate building the rpm package.