### PR TITLE
change ssdeep-lib to ssdeep-libs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -45,7 +45,7 @@ Install required packages.
 
     $ sudo yum groupinstall "Development Tools"
     $ sudo yum install epel-release
-    $ sudo yum install libffi-devel python-devel python-pip ssdeep-devel ssdeep-lib
+    $ sudo yum install libffi-devel python-devel python-pip ssdeep-devel ssdeep-libs
 
 Build and install Python module.
 


### PR DESCRIPTION
I believe the correct yum package is called `ssdeep-libs` instead of `ssdeep-lib`:
https://dl.fedoraproject.org/pub/epel/7/x86_64/s/ssdeep-libs-2.13-1.el7.x86_64.rpm