### PR TITLE
Docs - add Fedora-specific installation instructions

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -300,8 +300,8 @@ Build and install Python module.
 
     $ BUILD_LIB=1 pip3 install ssdeep
     
-    Install on Fedora 27
--------------------
+Install on Fedora 27
+--------------------
 
 Python 2
 ~~~~~~~~
@@ -321,8 +321,8 @@ Build and install Python module.
 
     $ sudo pip install ssdeep
     
-   Python 3
-   ~~~~~~~~
+Python 3
+~~~~~~~~
    
 
 **Use lib from Fedora repository**

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -299,7 +299,7 @@ Build and install Python module.
 .. code-block:: console
 
     $ BUILD_LIB=1 pip3 install ssdeep
-    
+
 Install on Fedora 27
 --------------------
 
@@ -320,10 +320,9 @@ Build and install Python module.
 .. code-block:: console
 
     $ sudo pip install ssdeep
-    
+
 Python 3
 ~~~~~~~~
-   
 
 **Use lib from Fedora repository**
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -299,3 +299,43 @@ Build and install Python module.
 .. code-block:: console
 
     $ BUILD_LIB=1 pip3 install ssdeep
+    
+    Install on Fedora 27
+-------------------
+
+Python 2
+~~~~~~~~
+
+**Use lib from Fedora repository**
+
+Install required packages.
+
+.. code-block:: console
+
+    $ sudo dnf groupinstall "Development Tools"
+    $ sudo dnf install libffi-devel python-devel python-pip ssdeep-devel ssdeep-libs
+
+Build and install Python module.
+
+.. code-block:: console
+
+    $ sudo pip install ssdeep
+    
+   Python 3
+   ~~~~~~~~
+   
+
+**Use lib from Fedora repository**
+
+Install required packages.
+
+.. code-block:: console
+
+    $ sudo dnf groupinstall "Development Tools"
+    $ sudo dnf install libffi-devel python3-devel python3-pip ssdeep-devel ssdeep-libs
+
+Build and install Python module.
+
+.. code-block:: console
+
+    $ sudo pip3 install ssdeep


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest or add a new one: -->
 - Documentation

##### SUMMARY
<!--- Describe your change. -->

I've added installation instructions for fedora 27, using the ssdeep libraries found on dnf.