### PR TITLE
Support for copy()

### DIFF
--- a/src/ssdeep/__init__.py
+++ b/src/ssdeep/__init__.py
@@ -44,6 +44,25 @@ class Hash(object):
         if self._state == ffi.NULL:
             raise InternalError("Unable to create state object")
 
+    def copy(self):
+        """
+        Create a copy of this hash object.
+
+        :return: Return a copy of the hash object.
+        :rtype: Hash
+        :raises InternalError: If the lib returns an internal error
+        """
+        if self._state == ffi.NULL:
+            raise InternalError("State object is NULL")
+
+        newstate = binding.lib.fuzzy_clone(self._state)
+        if newstate == ffi.NULL:
+            raise InternalError("cloning of fuzzy state object failed")
+
+        new = Hash.__new__(Hash)
+        new._state = newstate
+        return new
+
     def update(self, buf, encoding="utf-8"):
         """
          Feed the data contained in the given buffer to the state.

--- a/src/ssdeep/__init__.py
+++ b/src/ssdeep/__init__.py
@@ -130,6 +130,18 @@ class PseudoHash(object):
     def __init__(self):
         self._data = b""
 
+    def copy(self):
+        """
+        Create a copy of this hash object.
+
+        :return: Return a copy of the hash object.
+        :rtype: PseudoHash
+        :raises InternalError: If the lib returns an internal error
+        """
+        new = PseudoHash()
+        new.update(self._data)
+        return new
+
     def update(self, buf, encoding="utf-8"):
         """
          Feed the data contained in the given buffer to the state.

--- a/src/ssdeep/binding.py
+++ b/src/ssdeep/binding.py
@@ -11,6 +11,11 @@ cdef = """
 
     struct fuzzy_state;
     struct fuzzy_state *fuzzy_new(void);
+
+    struct fuzzy_state *fuzzy_clone(
+        const struct fuzzy_state *
+    );
+
     int fuzzy_update(
         struct fuzzy_state *,
         const unsigned char *,
@@ -62,6 +67,7 @@ source = """
     struct fuzzy_state {};
     const long FUZZY_FLAG_ELIMSEQ = 0;
     const long FUZZY_FLAG_NOTRUNC = 0;
+    int (*fuzzy_clone)(const struct fuzzy_state *) = NULL;
     int (*fuzzy_digest)(
         const struct fuzzy_state *,
         char *,
@@ -91,6 +97,7 @@ CONDITIONAL_NAMES = {
     "ssdeep_HAS_STATEFUL_HASHING": (
         "FUZZY_FLAG_ELIMSEQ",
         "FUZZY_FLAG_NOTRUNC",
+        "fuzzy_clone",
         "fuzzy_digest",
         "fuzzy_free",
         "fuzzy_new",

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -73,6 +73,7 @@ class TestHashClass(object):
         obj = ssdeep.Hash()
         obj.update("Also called fuzzy hashes, ")
         new_obj = obj.copy()
+        assert isinstance(new_obj, ssdeep.Hash)
 
         res = obj.digest()
         new_res = new_obj.digest()
@@ -107,6 +108,7 @@ class TestPseudoHashClass(object):
         obj = ssdeep.PseudoHash()
         obj.update("Also called fuzzy hashes, ")
         new_obj = obj.copy()
+        assert isinstance(new_obj, ssdeep.PseudoHash)
 
         res = obj.digest()
         new_res = new_obj.digest()

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -69,6 +69,31 @@ class TestFunctions(object):
 
 
 class TestHashClass(object):
+    def test_copy(self):
+        obj = ssdeep.Hash()
+        obj.update("Also called fuzzy hashes, ")
+        new_obj = obj.copy()
+
+        res = obj.digest()
+        new_res = new_obj.digest()
+        assert res == "3:AXGBicFlF:AXGHR"
+        assert new_res == "3:AXGBicFlF:AXGHR"
+
+        # Update only original object
+        obj.update("Ctph can match inputs that have homologies.")
+
+        res = obj.digest()
+        new_res = new_obj.digest()
+        assert res == "3:AXGBicFlgVNhBGcL6wCrFQEv:AXGHsNhxLsr2C"
+        assert new_res == "3:AXGBicFlF:AXGHR"
+
+        # Update only new object
+        new_obj.update("Ctph can match inputs that have homologies.")
+        res = obj.digest()
+        new_res = new_obj.digest()
+        assert res == "3:AXGBicFlgVNhBGcL6wCrFQEv:AXGHsNhxLsr2C"
+        assert new_res == "3:AXGBicFlgVNhBGcL6wCrFQEv:AXGHsNhxLsr2C"
+
     def test_update(self):
         obj = ssdeep.Hash()
         obj.update("Also called fuzzy hashes, Ctph can match inputs that have homologies.")

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -103,6 +103,31 @@ class TestHashClass(object):
 
 
 class TestPseudoHashClass(object):
+    def test_copy(self):
+        obj = ssdeep.PseudoHash()
+        obj.update("Also called fuzzy hashes, ")
+        new_obj = obj.copy()
+
+        res = obj.digest()
+        new_res = new_obj.digest()
+        assert res == "3:AXGBicFlF:AXGHR"
+        assert new_res == "3:AXGBicFlF:AXGHR"
+
+        # Update only original object
+        obj.update("Ctph can match inputs that have homologies.")
+
+        res = obj.digest()
+        new_res = new_obj.digest()
+        assert res == "3:AXGBicFlgVNhBGcL6wCrFQEv:AXGHsNhxLsr2C"
+        assert new_res == "3:AXGBicFlF:AXGHR"
+
+        # Update only new object
+        new_obj.update("Ctph can match inputs that have homologies.")
+        res = obj.digest()
+        new_res = new_obj.digest()
+        assert res == "3:AXGBicFlgVNhBGcL6wCrFQEv:AXGHsNhxLsr2C"
+        assert new_res == "3:AXGBicFlgVNhBGcL6wCrFQEv:AXGHsNhxLsr2C"
+
     def test_update(self):
         obj = ssdeep.PseudoHash()
         obj.update("Also called fuzzy hashes, ")


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest or add a new one: -->
 - Feature

##### SUMMARY
<!--- Describe your change. -->

Add copy function to return a copy of the hash object. This can be used to efficiently compute the digests of data sharing a common initial substring.
<!---
If you are fixing an existing issue, please include also "Fixes #nnn" in your commit message.
Please respect the preferred format of the commit message.
-->
