### PR TITLE
Remove pytest-runner from setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 import setuptools
 from distutils.sysconfig import get_config_vars
-from pkg_resources import parse_version
 from setuptools import Distribution as _Distribution, setup
 from setuptools.command.build_ext import build_ext as _build_ext
 import errno
@@ -144,14 +143,6 @@ with open(os.path.join(src_dir, "ssdeep", "__about__.py")) as f:
 with open(os.path.join(base_dir, "README.rst")) as f:
     long_description = f.read()
 
-# On some systems(e.g. Debian 8, CentOS 7) the setuptools package is very old.
-# We try to install an old version of pytest-runner without setuptools_scm dependency.
-# See: https://github.com/pytest-dev/pytest-runner/blob/master/CHANGES.rst
-if parse_version(setuptools.__version__) < parse_version("12"):
-    setup_requires = ["pytest-runner<2.4"]
-else:
-    setup_requires = ["pytest-runner"]
-
 
 setup(
     name=about["__title__"],
@@ -185,7 +176,7 @@ setup(
     ],
     setup_requires=[
         "cffi>=1.0.0",
-    ] + setup_requires,
+    ],
     tests_require=[
         "pytest",
     ],

--- a/setup.py
+++ b/setup.py
@@ -177,10 +177,10 @@ setup(
     setup_requires=[
         "cffi>=1.0.0",
     ],
-    tests_require=[
-        "pytest",
-    ],
     extras_require={
+        "test": [
+            "pytest",
+        ],
         "docstest": [
             "doc8",
             "readme_renderer >= 16.0",


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest or add a new one: -->
 - Bugfix

##### SUMMARY
<!--- Describe your change. -->

<!---
If you are fixing an existing issue, please include also "Fixes #nnn" in your commit message.
Please respect the preferred format of the commit message.
-->

Removes `pytest-runner` from `setup_requires`.

The `pytest-runner` package has been deprecated upstream for some time, and the project is now archived:
https://github.com/pytest-dev/pytest-runner/tree/v6.0.1?tab=readme-ov-file#deprecation-notice

Furthermore, the "setup.py test" command was removed in setuptools 72: https://github.com/pypa/setuptools/blob/v75.8.0/NEWS.rst#v7200

This does not affect running the tests with pytest or tox.

Fixes #57.